### PR TITLE
pausa cena durante minigame

### DIFF
--- a/Projeto/UI/Eventos/CortarAlimento.gd
+++ b/Projeto/UI/Eventos/CortarAlimento.gd
@@ -5,10 +5,12 @@ func _ready() -> void:
 	%ProgressoEvento.failed.connect(_on_failed)
 	%ProgressoEvento.completed.connect(_on_completed)
 	%ProgressoEvento.start()
+	get_tree().paused = true
 	
 func close() -> void:
 	GuiTransitions.hide("Modal")
 	await GuiTransitions.hide_completed
+	get_tree().paused = false
 	queue_free()
 
 func _on_close_button_button_down() -> void:

--- a/Projeto/UI/Eventos/CortarAlimento.tscn
+++ b/Projeto/UI/Eventos/CortarAlimento.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="Script" uid="uid://44oftg34g52d" path="res://addons/events/behavior/smash_button.gd" id="4_w4mwm"]
 
 [node name="CortarAlimento" instance=ExtResource("1_s7xxv")]
+process_mode = 2
 
 [node name="Label" type="Label" parent="MarginContainer/PanelContainer/VBoxContainer" index="1"]
 layout_mode = 2


### PR DESCRIPTION
Ao entrar no minigame, a cena por baixo da overlay/modal continuava rodando. Isso significa que quem joga pode mover a personagem para outros pontos da tela durante o minigame, e até mesmo interagir com o botão que carregou o minigame, fazendo com que ele seja recarregado por cima do atual antes que entre num estado de sucesso ou falha.

Esse patch corrige isso transformando o modo de processamento da cena "CortarAlimento.tscn" para "Enquanto Pausado" ("While Paused") e pausando a cena principal quando essa modal de minigame é carregada. Ao fechar, o restante da cena é despausado.

Vale notar que demais cenas de minigame precisarão que o mesmo ajuste seja feito nelas. Caso o patch seja aprovado, minha sugestão é ajustar o código para que possamos fazer isso em um local central de modo que as sub-cenas não precisem se preocupar com a lógica de instanciação/destruição.

É isso <3