### PR TITLE
ignora cache e arquivos temporários do projeto

### DIFF
--- a/Projeto/.gitignore
+++ b/Projeto/.gitignore
@@ -1,3 +1,17 @@
-# Godot 4+ specific ignores
+# Godot 4+:
 .godot/
 /android/
+
+# artefatos da build:
+export.cfg
+*.zip
+*.pck
+
+# se usarmos a AssetLib do Godot:
+addons/
+
+# cache e arquivos temporários:
+*.tmp
+*~
+**/.DS_Store
+.vscode/


### PR DESCRIPTION
Esse patch incrementa o .gitignore do projeto para desconsiderar também arquivos de cache e temporários fora do ".godot/". Isso deve ajudar a gente a commitar só o que é relevante ao projeto e ignorar artefatos de editores, build, etc.