### PR TITLE
fluxos de trabalho para github actions

### DIFF
--- a/.github/workflows/main-no-branch-de-arte.yml
+++ b/.github/workflows/main-no-branch-de-arte.yml
@@ -13,14 +13,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: arte
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Lendo última versão da main
         run: |
-          git fetch origin main
+          git fetch origin main --depth=1000 # garante que acha ancestral comum entre main e arte
 
       - name: Inserindo Main dentro de Arte
         run: |
-          git merge origin/main -s recursive -X patience
+          git config user.name "Bot Sincronizador da Main"
+          git config user.email "bot@github.com"
+          # só crie o commit de merge se necessário:
+          git merge origin/main --ff-only || git merge origin/main --no-ff -m "Atualizando Arte com a Main"
 
       - name: Atualizando repositório de arte
         run: |

--- a/.github/workflows/main-no-branch-de-arte.yml
+++ b/.github/workflows/main-no-branch-de-arte.yml
@@ -1,0 +1,27 @@
+name: Main no Branch de Arte
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Obtendo repositório de arte
+        uses: actions/checkout@v4
+        with:
+          ref: arte
+
+      - name: Lendo última versão da main
+        run: |
+          git fetch origin main
+
+      - name: Inserindo Main dentro de Arte
+        run: |
+          git merge origin/main -s recursive -X patience
+
+      - name: Atualizando repositório de arte
+        run: |
+          git push origin arte

--- a/.github/workflows/validacao-branch-arte.yml
+++ b/.github/workflows/validacao-branch-arte.yml
@@ -1,0 +1,50 @@
+name: Validação do Branch de Arte
+
+on:
+  push:
+    branches:
+      - arte
+
+jobs:
+  valida:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acessa Repositório
+        uses: actions/checkout@v4
+
+      - name: Valida Assets de Arte
+        run: |
+          CAMINHOS_VALIDOS=("Recursos/Graficos/" "Projeto/Recursos/Graficos")
+          TIPOS_VALIDOS=("\.png" "\.svg" "\.import")
+
+          ARQUIVOS_ALTERADOS=$(git diff --cached --name-only)
+
+          for ARQUIVO in $ARQUIVOS_ALTERADOS; do
+            # verifica pasta:
+            ACHOU_DIR=false
+            for DIR in "${CAMINHOS_VALIDOS[@]}"; do
+              if [[ "$ARQUIVO" == $DIR* ]]; then
+                ACHOU_DIR=true
+                break
+              fi
+            done
+            if ! $ACHOU_DIR; then
+              echo "❌ Arquivo '$ARQUIVO' não está num caminho válido (precisa ser em ${CAMINHOS_VALIDOS[*]})"
+              exit 1
+            fi
+
+            # verifica tipo:
+            ACHOU_TIPO=false
+            for TIPO in "${TIPOS_VALIDOS[@]}"; do
+              if [[ "$ARQUIVO" =~ $TIPO ]]; then
+                ACHOU_TIPO=true
+                break
+              fi
+            done
+            if ! ACHOU_TIPO; then
+              echo "❌ Arquivo '$FILE' não tem extensão válida (precisa ser em ${TIPOS_VALIDOS[*]})"
+              exit 1
+            fi
+          done
+
+          echo "✅ mudanças validadas!"

--- a/.github/workflows/validacao-branch-arte.yml
+++ b/.github/workflows/validacao-branch-arte.yml
@@ -11,38 +11,53 @@ jobs:
     steps:
       - name: Acessa Repositório
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Obtém origin/main
+        run: git fetch origin main
 
       - name: Valida Assets de Arte
         run: |
           CAMINHOS_VALIDOS=("Recursos/Graficos/" "Projeto/Recursos/Graficos")
-          TIPOS_VALIDOS=("\.png" "\.svg" "\.import")
+          TIPOS_VALIDOS=("png" "svg" "import")
 
-          ARQUIVOS_ALTERADOS=$(git diff --cached --name-only)
+          ARQUIVOS_ALTERADOS=$(git diff --name-only origin/main..arte)
 
+          # olha arquivos diferentes entre main e arte
           for ARQUIVO in $ARQUIVOS_ALTERADOS; do
+
+            # ignora se mudança está na main
+            if git show origin/main:"$ARQUIVO" &>/dev/null; then
+              continue
+            fi
+
             # verifica pasta:
             ACHOU_DIR=false
             for DIR in "${CAMINHOS_VALIDOS[@]}"; do
-              if [[ "$ARQUIVO" == $DIR* ]]; then
+              if [[ "$ARQUIVO" == "$DIR"* ]]; then
                 ACHOU_DIR=true
                 break
               fi
             done
+
             if ! $ACHOU_DIR; then
-              echo "❌ Arquivo '$ARQUIVO' não está num caminho válido (precisa ser em ${CAMINHOS_VALIDOS[*]})"
+            echo "::error:: Arquivo '$ARQUIVO' não está num caminho válido (precisa ser em ${CAMINHOS_VALIDOS[*]})"
               exit 1
             fi
 
             # verifica tipo:
+            EXTENSAO="${ARQUIVO##*.}"
             ACHOU_TIPO=false
             for TIPO in "${TIPOS_VALIDOS[@]}"; do
-              if [[ "$ARQUIVO" =~ $TIPO ]]; then
+              if [[ "$EXTENSAO" == "$TIPO" ]]; then
                 ACHOU_TIPO=true
                 break
               fi
             done
-            if ! ACHOU_TIPO; then
-              echo "❌ Arquivo '$FILE' não tem extensão válida (precisa ser em ${TIPOS_VALIDOS[*]})"
+
+            if ! $ACHOU_TIPO; then
+            echo "::error:: Arquivo '$ARQUIVO' não tem extensão válida (precisa ser em ${TIPOS_VALIDOS[*]})"
               exit 1
             fi
           done


### PR DESCRIPTION
Conforme conversado, esse PR adiciona os fluxos de trabalho para que o github mantenha o branch "arte" sempre atualizado em relação à "main".

Para garantir que o branch "arte" permaneça consistente e sem revisão de código, é importante que somente recursos de arte sejam modificados nele. Por isso, fiz um segundo fluxo aceitando pushes no "arte" somente de arquivos de arte (.png, .svg e .import) e somente nos caminhos pre-estabelecidos.

O branch de arte já existe e pode ser usado imediatamente, porém de preferência somente após esse PR ser aceito e incorporado ao "main".