### PR TITLE
integra passo de publicacao na itch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,8 @@
-name: Main no Branch de Arte
+name: Integração e Distribuição Contínua
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
 
 jobs:
   merge:
@@ -30,3 +29,11 @@ jobs:
       - name: Atualizando repositório de arte
         run: |
           git push origin arte
+
+  publica:
+    needs: merge
+    uses: ./.github/workflows/publica-na-itch.yml
+    with:
+      nome_na_itch: qtftp2teste
+      usuario_na_itch: ntmtst
+      branch: arte

--- a/.github/workflows/publica-na-itch.yml
+++ b/.github/workflows/publica-na-itch.yml
@@ -1,0 +1,67 @@
+name: Publica na Itch
+# Esse fluxo não roda sozinho, precisa ser chamado a partir de outro
+# com os parâmetros específicos do projeto. Por exemplo:
+#
+# jobs:
+#   publica:
+#     name: Publica na Itch
+#     needs: dependencia-anterior-opcional
+#     uses: ./.github/workflows/publica-na-itch.yml
+#     with:
+#       nome_na_itch: qtftp2teste
+#       usuario_na_itch: ntmtst
+#       branch: arte
+#
+# Ele assume a seguinte estrutura de pastas no repositório:
+#
+#   .
+#   ├── Projeto/   <-- código fonte do jogo em Godot
+#   └── Release/   <-- destino do jogo montado
+#       └── Web    <-- destino do jogo versão web
+#
+# Também assume que o jogo é em Godot 4 usando GDScript e não C#.
+# Finalmente, para a publicação funcionar, você precisa ter a chave
+# da Itch dentro dos segredos do Github, em ITCH_IO_KEY.
+
+on:
+  workflow_call:
+    inputs:
+      nome_na_itch:
+        required: true
+      usuario_na_itch:
+        required: true
+      branch:
+        required: true
+
+env:
+  GODOT_VERSAO: '4.4'
+
+jobs:
+  exporta-pra-itch:
+    name: Exporta pra Itch
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:4.4  # não aceita interpolação de ${{ GODOT_VERSAO }}
+    steps:
+      - name: Obtendo repositório
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+      - name: Configurando
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mv -v /root/.local/share/godot/export_templates/${GODOT_VERSAO}.stable ~/.local/share/godot/export_templates/${GODOT_VERSAO}.stable
+      - name: Montando para Web
+        working-directory: ./Projeto
+        run: |
+          godot -v --headless --export-release Web ../Release/Web/index.html
+      - name: Publicando na Itch
+        uses: yeslayla/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.ITCH_IO_KEY }}
+          CHANNEL: web
+          ITCH_GAME: ${{ inputs.nome_na_itch }}
+          ITCH_USER: ${{ inputs.usuario_na_itch }}
+          PACKAGE: ./Release/Web


### PR DESCRIPTION
Esse PR, ao ser aceito, fará todo push na main produzir uma build para Web e enviar ao Itch.io.

A action de build e upload no itch foi separada para que, ao final do projeto, com os devidos ajustes ao longo, possamos deixá-la num repositório à parte, para que seja usada facilmente em todos os projetos de jogos do NTMTST.

Uma questão importante: a build gerada não é atualizada no repositório. Considero isso uma feature, e sugiro que a gente apague completamente os artefatos de /Release de todo o histórico (o que deixará o projeto inclusive mais leve para clone/fork). Se quisermos guardar histórico de builds, podemos fazer o upload dos artefatos para o github (em "releases") e não para o controle de versão em si.

Mas, claro, se preferirem manter um commit com a build automática dentro do controle de versão, é só sinalizar que atualizo aqui o PR.