### PR TITLE
adiciona tipo a parametros obrigatórios a workflow

### DIFF
--- a/.github/workflows/publica-na-itch.yml
+++ b/.github/workflows/publica-na-itch.yml
@@ -27,10 +27,13 @@ on:
   workflow_call:
     inputs:
       nome_na_itch:
+        type: string
         required: true
       usuario_na_itch:
+        type: string
         required: true
       branch:
+        type: string
         required: true
 
 env:


### PR DESCRIPTION
A ação de publicação na Itch, ao ser isolada para reutilização, passou a receber parâmetros. Só que a versão atual da especificação dos workflows do github [exige a definição do tipo de cada parâmetro](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onworkflow_callinputs), que estava faltando.