### PR TITLE
permite acelerar tempo da musica durante a fase

### DIFF
--- a/Projeto/Scripts/ControleDeAudio.gd
+++ b/Projeto/Scripts/ControleDeAudio.gd
@@ -1,8 +1,10 @@
 extends Node
 
+const TOM_MAXIMO := 2.4
+const INCREMENTO_DE_TOM := 1.2
 const TAMANHO_DO_GRUPO_DE_EFEITOS := 5
-var toca_efeitos := []
 
+var toca_efeitos := []
 var biblioteca_de_audio := {
 	"musica": {
 		"casa_intro": preload("res://Recursos/Audio/Musica/casa_intro.ogg"),
@@ -21,18 +23,32 @@ var biblioteca_de_audio := {
 	}
 }
 
+var musica_acelera: bool
+var efeito_de_pitch: AudioEffectPitchShift
 var toca_musica_intro: AudioStreamPlayer
 var toca_musica_ciclo: AudioStreamPlayer
 
+
 func _ready() -> void:
+	musica_acelera = false
 	toca_musica_intro = AudioStreamPlayer.new()
 	toca_musica_intro.bus = "Musica"
 	add_child(toca_musica_intro)
 	toca_musica_intro.finished.connect(_on_intro_finalizada)
 
+	efeito_de_pitch = AudioEffectPitchShift.new()
+	efeito_de_pitch.pitch_scale = 1.0
+	efeito_de_pitch.fft_size =AudioEffectPitchShift.FFT_SIZE_2048
+	efeito_de_pitch.oversampling = 4
+	var indice_do_barramento = AudioServer.get_bus_index("Musica")
+	AudioServer.add_bus_effect(indice_do_barramento, efeito_de_pitch, 0)
+	AudioServer.set_bus_effect_enabled(indice_do_barramento, 0, true)
+
 	toca_musica_ciclo = AudioStreamPlayer.new()
 	toca_musica_ciclo.bus = "Musica"
+	toca_musica_ciclo.pitch_scale = 1.0
 	add_child(toca_musica_ciclo)
+	toca_musica_ciclo.finished.connect(_on_musica_ciclo_completo)
 
 	for i in TAMANHO_DO_GRUPO_DE_EFEITOS:
 		var tocador = AudioStreamPlayer.new()
@@ -41,32 +57,32 @@ func _ready() -> void:
 		toca_efeitos.append(tocador)
 
 
-func toca_musica(nome_da_faixa: String) -> void:
+func volume_da_musica(volume: float) -> void:
+	_ajusta_volume_do_barramento("Musica", volume)
+
+
+func volume_de_efeitos(volume: float) -> void:
+	_ajusta_volume_do_barramento("Efeitos", volume)
+
+
+func toca_musica(nome_da_faixa: String, acelera: bool = true) -> void:
+	musica_acelera = acelera
 	var stream = biblioteca_de_audio["musica"].get(nome_da_faixa)
 	if !stream: return
-	if toca_musica_ciclo.stream != stream:
-		para_musica()
-		toca_musica_ciclo.stream = stream
-		toca_musica_ciclo.stream.loop = true
-		toca_musica_ciclo.play()
-
-func toca_musica_com_intro(nome_faixa_intro: String, nome_faixa_ciclo: String) -> void:
-	var intro = biblioteca_de_audio["musica"].get(nome_faixa_intro)
-	var ciclo = biblioteca_de_audio["musica"].get(nome_faixa_ciclo)
-
-	if !intro || !ciclo: return
-
 	para_musica()
-
-	toca_musica_intro.stream = intro
-	toca_musica_ciclo.stream = ciclo
-	toca_musica_ciclo.stream.loop = true
-
-	toca_musica_intro.play()
-
-
-func _on_intro_finalizada() -> void:
+	_prepara_musica_ciclo(stream)
 	toca_musica_ciclo.play()
+
+
+func toca_musica_com_intro(nome_intro: String, nome_ciclo: String, acelera: bool = true) -> void:
+	musica_acelera = acelera
+	var intro = biblioteca_de_audio["musica"].get(nome_intro)
+	var ciclo = biblioteca_de_audio["musica"].get(nome_ciclo)
+	if !intro || !ciclo: return
+	para_musica()
+	_prepara_musica_ciclo(ciclo)
+	toca_musica_intro.stream = intro
+	toca_musica_intro.play()
 
 
 func para_musica() -> void:
@@ -93,21 +109,45 @@ func toca_efeito(nome_do_efeito: String) -> void:
 	tocador.pitch_scale = 1.0
 	tocador.play()
 
+
+func _prepara_musica_ciclo(stream: AudioStream) -> void:
+	toca_musica_ciclo.stream = stream
+	# nosso loop é manual para podermos ajustar a velocidade da música.
+	toca_musica_ciclo.stream.loop = false
+	toca_musica_ciclo.pitch_scale = 1.0
+	efeito_de_pitch.pitch_scale = 1.0
+
+
+func _on_musica_ciclo_completo() -> void:
+	if musica_acelera: _aumenta_velocidade_da_musica()
+	toca_musica_ciclo.play()
+
+
+func _aumenta_velocidade_da_musica() -> void:
+	var tom_atual = toca_musica_ciclo.pitch_scale
+	if tom_atual == TOM_MAXIMO: return
+	tom_atual *= INCREMENTO_DE_TOM
+	if tom_atual > TOM_MAXIMO:
+		tom_atual = TOM_MAXIMO
+		return
+	efeito_de_pitch.pitch_scale /= INCREMENTO_DE_TOM
+	toca_musica_ciclo.pitch_scale = tom_atual
+
+
+func _on_intro_finalizada() -> void:
+	toca_musica_ciclo.play()
+
+
 func _encontra_tocador_disponivel() -> AudioStreamPlayer:
 	for tocador in toca_efeitos:
 		if !tocador.playing:
 			return tocador
 	# cria tocador temporário se não houver um disponível:
-	push_warning("Impossível tocar efeito. Grupo pequeno demais.")
+	push_warning("Impossível tocar efeito sonoro. Grupo pequeno demais.")
 	return null
 
-func volume_da_musica(volume: float) -> void:
-	ajusta_volume_do_barramento("Musica", volume)
 
-func volume_de_efeitos(volume: float) -> void:
-	ajusta_volume_do_barramento("Efeitos", volume)
-
-func ajusta_volume_do_barramento(nome_do_barramento: String, volume: float) -> void:
+func _ajusta_volume_do_barramento(nome_do_barramento: String, volume: float) -> void:
 	var indice_do_barramento = AudioServer.get_bus_index(nome_do_barramento)
 	if indice_do_barramento >= 0:
 		AudioServer.set_bus_volume_db(indice_do_barramento, linear_to_db(volume))


### PR DESCRIPTION
Esse PR ajusta o controle de audio do jogo para permitir (ativo por padrão) que, a cada ciclo da música, o tempo seja levemente acelerado, visando a indicação sonora de que o tempo está acabando e incrementando a sensação de urgência.

Note que o tempo (velocidade da música) acelera sem modificar o tom. Isso é feito abusando da classe AudioEffectPitchShift, que foi criada para alterar o tom sem alterar o tempo. Como o que a gente queria era o contrário, e o ajuste de tom do AudioStreamPlayer acelera também o tempo, eu ajusto ambos, multiplicando pelo fator em um e dividindo no outro.

Feito em parceria com o Pedrin 🎵 