### PR TITLE
corrige warnings e erros do editor

### DIFF
--- a/Projeto/Componentes/Personagens/Player.tscn
+++ b/Projeto/Componentes/Personagens/Player.tscn
@@ -528,6 +528,9 @@ metadata/_local_pose_override_enabled_ = true
 [node name="PernaEsq_1" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril/PernaEsq_0"]
 position = Vector2(-8, 20)
 rest = Transform2D(1, 0, 0, 1, -8, 20)
+auto_calculate_length_and_angle = false
+length = 16.0
+bone_angle = 0.0
 
 [node name="PernaDir_0" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril"]
 position = Vector2(-10, 0)
@@ -537,6 +540,9 @@ metadata/_local_pose_override_enabled_ = true
 [node name="PernaDir_1" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril/PernaDir_0"]
 position = Vector2(-8, 19)
 rest = Transform2D(1, 0, 0, 1, -8, 19)
+auto_calculate_length_and_angle = false
+length = 16.0
+bone_angle = 0.0
 
 [node name="Peito" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril"]
 position = Vector2(-4.53922, -31.5392)
@@ -546,6 +552,9 @@ metadata/_local_pose_override_enabled_ = true
 [node name="Cabeca" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril/Peito"]
 position = Vector2(1, -66)
 rest = Transform2D(1, 0, 0, 1, 1, -66)
+auto_calculate_length_and_angle = false
+length = 16.0
+bone_angle = 0.0
 
 [node name="BracoEsq_0" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril/Peito"]
 position = Vector2(22, -10)
@@ -556,6 +565,9 @@ metadata/_local_pose_override_enabled_ = true
 [node name="BracoEsq_1" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril/Peito/BracoEsq_0"]
 position = Vector2(12, 31)
 rest = Transform2D(1, 0, 0, 1, 12, 31)
+auto_calculate_length_and_angle = false
+length = 16.0
+bone_angle = 0.0
 
 [node name="BracoDir_0" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril/Peito"]
 position = Vector2(-12, -6)
@@ -567,6 +579,9 @@ metadata/_local_pose_override_enabled_ = true
 [node name="BracoDir_1" type="Bone2D" parent="GambiarraCamera/SpriteAnimado/Skeleton2D/Quadril/Peito/BracoDir_0"]
 position = Vector2(-11, 26)
 rest = Transform2D(1, 0, 0, 1, -11, 26)
+auto_calculate_length_and_angle = false
+length = 16.0
+bone_angle = 0.0
 
 [node name="Node" type="Node2D" parent="GambiarraCamera/SpriteAnimado"]
 

--- a/Projeto/project.godot
+++ b/Projeto/project.godot
@@ -27,10 +27,6 @@ ControleDeFase="*res://Scripts/ControleDeFase.gd"
 ControleDeAudio="*res://Scripts/ControleDeAudio.gd"
 DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
 
-[dialogue_manager]
-
-runtime/balloon_path="uid://cxus7xsj4lhv3"
-
 [display]
 
 window/size/viewport_width=720


### PR DESCRIPTION
Hoje no branch principal carregar o jogo no editor mostra 1 erro e 20 warnings:

```
Godot Engine v4.4.1.stable.official (c) 2007-present Juan Linietsky, Ariel Manzur & Godot Contributors.
--- Debug adapter server started on port 6006 ---
--- GDScript language server started on port 6005 ---
  ERROR: Unrecognized UID: "uid://cxus7xsj4lhv3".
Add Autoload
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node PernaEsq_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node PernaDir_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node Cabeca. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node BracoEsq_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node BracoDir_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node PernaEsq_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node PernaDir_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node Cabeca. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node BracoEsq_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
  WARNING: scene/2d/skeleton_2d.cpp:447 - No Bone2D children of node BracoDir_1. Cannot calculate bone length or angle reliably.
  WARNING: Using transform rotation for bone angle.
```

O erro acontece porque há um resquício do addon dialogue manager, provavelmente adicionado durante uma sessão de depuração, e a referência ficou lá por engano.
Os warnings acontecem porque as "folhas" de um Bone2D não conseguem fazer ajuste automático de tamanho ou ângulo (afinal, não estão tocando outra estrutura). A solução é ir na folha e desmarcar a opção "autocalcular tamanho e ângulo".

Esse patch corrige ambos. Nos testes, o balão de diálogo foi exibido corretamente, assim como os movimentos da personagem principal.