### PR TITLE
ajustes no grafico da bancada

### DIFF
--- a/Projeto/Componentes/Base/Interagiveis/pia.gd
+++ b/Projeto/Componentes/Base/Interagiveis/pia.gd
@@ -4,7 +4,7 @@ func _ready() -> void:
 	nome = "Pia"
 
 func _on_componente_interagivel_interagir(jogador: Player):
-	if jogador.esta_agarrando != null:
+	if jogador.esta_agarrando:
 		var objeto_ingrediente = jogador.objeto_agarrado
 		if objeto_ingrediente.ingrediente.acoes[0].alvo == "pia":
 			jogador.objeto_agarrado.acao_pia()

--- a/Projeto/Componentes/Casa/Interagiveis/Bancada.tscn
+++ b/Projeto/Componentes/Casa/Interagiveis/Bancada.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://c6ch38f6kai3t"]
 
 [ext_resource type="Script" uid="uid://78y5jrqf3oo4" path="res://Componentes/Base/Interagiveis/bancada.gd" id="1_awsmu"]
-[ext_resource type="Texture2D" uid="uid://b3ami1vh08c7k" path="res://Recursos/Graficos/Interagiveis/Bancada_Sep.svg" id="2_0dyue"]
+[ext_resource type="Texture2D" uid="uid://cc2dcwpo1ky2s" path="res://Recursos/Graficos/Interagiveis/Bancada.svg" id="2_0dyue"]
 [ext_resource type="Script" uid="uid://ddwsslb5nraqq" path="res://Componentes/Base/Interagiveis/componente_interagivel.gd" id="2_1yb7t"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_xld1x"]

--- a/Projeto/Componentes/Casa/Interagiveis/Pia.tscn
+++ b/Projeto/Componentes/Casa/Interagiveis/Pia.tscn
@@ -19,6 +19,7 @@ offset_top = -71.0
 offset_right = 121.0
 offset_bottom = 84.0
 texture = ExtResource("2_oc46i")
+stretch_mode = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(27.5, -5)

--- a/Projeto/Recursos/Graficos/Bagunca/lixo1.svg.import
+++ b/Projeto/Recursos/Graficos/Bagunca/lixo1.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://cm1aeymk1r000"
+path="res://.godot/imported/lixo1.svg-9a1a684a978b08b1b3a932a95cacde16.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Bagunca/lixo1.svg"
+dest_files=["res://.godot/imported/lixo1.svg-9a1a684a978b08b1b3a932a95cacde16.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Bagunca/lixo2.svg.import
+++ b/Projeto/Recursos/Graficos/Bagunca/lixo2.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://0x2l5f6yj6a2"
+path="res://.godot/imported/lixo2.svg-167f502b293455957b69cdf9025b7eb1.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Bagunca/lixo2.svg"
+dest_files=["res://.godot/imported/lixo2.svg-167f502b293455957b69cdf9025b7eb1.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Bagunca/lixo3.svg.import
+++ b/Projeto/Recursos/Graficos/Bagunca/lixo3.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://cyueyjxrn0b7s"
+path="res://.godot/imported/lixo3.svg-1c3179609074f467fd706861f8281b1d.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Bagunca/lixo3.svg"
+dest_files=["res://.godot/imported/lixo3.svg-1c3179609074f467fd706861f8281b1d.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Bagunca/lixo4.svg.import
+++ b/Projeto/Recursos/Graficos/Bagunca/lixo4.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://cn4fnnht3u7l0"
+path="res://.godot/imported/lixo4.svg-05e9f2692bd08a4a3d680ab9db31272f.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Bagunca/lixo4.svg"
+dest_files=["res://.godot/imported/lixo4.svg-05e9f2692bd08a4a3d680ab9db31272f.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Bagunca/lixo5.svg.import
+++ b/Projeto/Recursos/Graficos/Bagunca/lixo5.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://cdag7wf1yvgmw"
+path="res://.godot/imported/lixo5.svg-cd04387cc2dd3e9c8a0a661bc38b6206.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Bagunca/lixo5.svg"
+dest_files=["res://.godot/imported/lixo5.svg-cd04387cc2dd3e9c8a0a661bc38b6206.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/CozinhaSolidaria.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/CozinhaSolidaria.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://ctn2m4fhryhtn"
+path="res://.godot/imported/CozinhaSolidaria.svg-34a6973465b7913154c906f80ea27239.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/CozinhaSolidaria.svg"
+dest_files=["res://.godot/imported/CozinhaSolidaria.svg-34a6973465b7913154c906f80ea27239.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/PisoCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/PisoCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://ckwgsoywjl1en"
+path="res://.godot/imported/PisoCS.svg-13c6c19752abfb3fb24bd06fd1728190.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/PisoCS.svg"
+dest_files=["res://.godot/imported/PisoCS.svg-13c6c19752abfb3fb24bd06fd1728190.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/balcaoCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/balcaoCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://drb7dosrwyq4x"
+path="res://.godot/imported/balcaoCS.svg-3990c6452e8888a766fca2d011a41d95.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/balcaoCS.svg"
+dest_files=["res://.godot/imported/balcaoCS.svg-3990c6452e8888a766fca2d011a41d95.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/divisoriaCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/divisoriaCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://cafjtau05ef7n"
+path="res://.godot/imported/divisoriaCS.svg-6f4d76792decbf1d3948c4d2bea58318.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/divisoriaCS.svg"
+dest_files=["res://.godot/imported/divisoriaCS.svg-6f4d76792decbf1d3948c4d2bea58318.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/entradaCS_1.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/entradaCS_1.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://bnogi08qywfuq"
+path="res://.godot/imported/entradaCS_1.svg-4e74e5ab1beea664a7a4ff56b17e1fec.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/entradaCS_1.svg"
+dest_files=["res://.godot/imported/entradaCS_1.svg-4e74e5ab1beea664a7a4ff56b17e1fec.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/espelhoCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/espelhoCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://bvb6qkgyxnu8r"
+path="res://.godot/imported/espelhoCS.svg-c4dde31dcfce25310894745943d55fab.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/espelhoCS.svg"
+dest_files=["res://.godot/imported/espelhoCS.svg-c4dde31dcfce25310894745943d55fab.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/fogaoCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/fogaoCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://ckoocbrx77mdq"
+path="res://.godot/imported/fogaoCS.svg-7ec826abd92d83d5f816f7ae943db61a.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/fogaoCS.svg"
+dest_files=["res://.godot/imported/fogaoCS.svg-7ec826abd92d83d5f816f7ae943db61a.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/freezerCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/freezerCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://dkmxa34o46ua3"
+path="res://.godot/imported/freezerCS.svg-5d9a5d158926b3a0288af460e6f0f17f.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/freezerCS.svg"
+dest_files=["res://.godot/imported/freezerCS.svg-5d9a5d158926b3a0288af460e6f0f17f.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/mesaCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/mesaCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://bpqadw5bvlt77"
+path="res://.godot/imported/mesaCS.svg-4abfc1237a71e886972d44a7ad158488.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/mesaCS.svg"
+dest_files=["res://.godot/imported/mesaCS.svg-4abfc1237a71e886972d44a7ad158488.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/paredeCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/paredeCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://tcyqrfvs5jhe"
+path="res://.godot/imported/paredeCS.svg-f9ad2cc773231982361b543407f88b2c.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/paredeCS.svg"
+dest_files=["res://.godot/imported/paredeCS.svg-f9ad2cc773231982361b543407f88b2c.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/piaCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/piaCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://baqphxfel3yps"
+path="res://.godot/imported/piaCS.svg-e7a8fa0b288e3faa43d05850131daf27.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/piaCS.svg"
+dest_files=["res://.godot/imported/piaCS.svg-e7a8fa0b288e3faa43d05850131daf27.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/Cenas/placaCS.svg.import
+++ b/Projeto/Recursos/Graficos/Cenas/placaCS.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://5ngr8pw5rerx"
+path="res://.godot/imported/placaCS.svg-bca10044905e4ae3bdf7a667faf52292.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/Cenas/placaCS.svg"
+dest_files=["res://.godot/imported/placaCS.svg-bca10044905e4ae3bdf7a667faf52292.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://b6j4tevc77h8a"
+path="res://.godot/imported/dialog_box_base_bottom.svg-195e03a29ba5c0297019350a5cdfdcb4.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom.svg"
+dest_files=["res://.godot/imported/dialog_box_base_bottom.svg-195e03a29ba5c0297019350a5cdfdcb4.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom_left.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom_left.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://bxu7hlnc8qh7j"
+path="res://.godot/imported/dialog_box_base_bottom_left.svg-8edec351cf9a85983497fbbc606476dc.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom_left.svg"
+dest_files=["res://.godot/imported/dialog_box_base_bottom_left.svg-8edec351cf9a85983497fbbc606476dc.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom_right.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom_right.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://bku8yaeifmhia"
+path="res://.godot/imported/dialog_box_base_bottom_right.svg-f56cf94c843275aef3abe0f644660517.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_bottom_right.svg"
+dest_files=["res://.godot/imported/dialog_box_base_bottom_right.svg-f56cf94c843275aef3abe0f644660517.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_middle_left.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_middle_left.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://ddsj0xg16ta45"
+path="res://.godot/imported/dialog_box_base_middle_left.svg-99b917ca5f2d423a1b49ddb7248271ff.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_middle_left.svg"
+dest_files=["res://.godot/imported/dialog_box_base_middle_left.svg-99b917ca5f2d423a1b49ddb7248271ff.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_middle_right.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_middle_right.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://cvanjolniao8e"
+path="res://.godot/imported/dialog_box_base_middle_right.svg-e07a87ea206a74372e099cda202b6e96.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_middle_right.svg"
+dest_files=["res://.godot/imported/dialog_box_base_middle_right.svg-e07a87ea206a74372e099cda202b6e96.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://v3ghfnyergpq"
+path="res://.godot/imported/dialog_box_base_top.svg-11e760a52e46caa94ed880e6bf335b2e.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top.svg"
+dest_files=["res://.godot/imported/dialog_box_base_top.svg-11e760a52e46caa94ed880e6bf335b2e.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top_left.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top_left.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://shldoep0a8vo"
+path="res://.godot/imported/dialog_box_base_top_left.svg-b897ff2356bba6c3748f6293b9e9fdf2.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top_left.svg"
+dest_files=["res://.godot/imported/dialog_box_base_top_left.svg-b897ff2356bba6c3748f6293b9e9fdf2.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top_right.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top_right.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://dwnnrsb3pp2yg"
+path="res://.godot/imported/dialog_box_base_top_right.svg-85132ec760bb258c79aa620d5ffff72e.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_base_top_right.svg"
+dest_files=["res://.godot/imported/dialog_box_base_top_right.svg-85132ec760bb258c79aa620d5ffff72e.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_icon_next.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_icon_next.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://c1f34a424eiiv"
+path="res://.godot/imported/dialog_box_icon_next.svg-501919c4ca07e7674f0f2471870c728a.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_icon_next.svg"
+dest_files=["res://.godot/imported/dialog_box_icon_next.svg-501919c4ca07e7674f0f2471870c728a.ctex"]
 
 [params]
 

--- a/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_tip.svg.import
+++ b/Projeto/Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_tip.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cnva0fw1epbgd"
-path="res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"
+uid="uid://b6q8p1m84vvw1"
+path="res://.godot/imported/dialog_box_tip.svg-07fb9c68c4c2d787c52917c007e3e0eb.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Recursos/Graficos/Bagunca/Bagunca.svg"
-dest_files=["res://.godot/imported/Bagunca.svg-4de234dadb030330f7e037fbefe37386.ctex"]
+source_file="res://Recursos/Graficos/UI/Componentes/dialog_box/dialog_box_tip.svg"
+dest_files=["res://.godot/imported/dialog_box_tip.svg-07fb9c68c4c2d787c52917c007e3e0eb.ctex"]
 
 [params]
 


### PR DESCRIPTION
Após a mudança nos recursos de arte da bancada, a pia ficou gigante e a bancada ficou partida no meio. Esse patch resolve a questão.

main antes desse PR:
<img width="331" height="166" alt="antes" src="https://github.com/user-attachments/assets/1e06372a-25e8-4ef3-a74b-2d9e9206156e" />

main depois desse PR:
<img width="262" height="146" alt="depois" src="https://github.com/user-attachments/assets/db3b4844-e81f-4616-aa2c-f50de63e005f" />
