### PR TITLE
elimina erro no add_sibling()

### DIFF
--- a/Projeto/Componentes/Personagens/player.gd
+++ b/Projeto/Componentes/Personagens/player.gd
@@ -58,6 +58,7 @@ func _input(_event: InputEvent) -> void:
 
 
 func agarrar(objeto: Node):
+	if objeto.get_parent(): objeto.get_parent().remove_child(objeto)
 	add_sibling(objeto)
 	objeto_agarrado = objeto
 	_agarrar()


### PR DESCRIPTION
O `add_sibling()` retorna erro se o objeto a ser adicionado já está na árvore. Então, antes de usarmos, precisamos garantir que ele não tenha pai.

Vale notar que não sei o motivo desse add_sibling() estar aí, porque logo depois é feito um `reparent()` que é uma forma limpa de colocar o item na árvore. Minha sugestão para o polimento disso é acabar com o add_sibling() e, logo após o reparent(), fazer algo como:

```gdsdcript
   move_child(objeto_agarrado, get_index() + 1)
```

Isso deve, acredito, ser o suficiente, eliminando o erro e a verificação introduzida nesse commit.