### PR TITLE
desativa botão continuar se não houver saves

### DIFF
--- a/Projeto/UI/Menus/menu_principal.gd
+++ b/Projeto/UI/Menus/menu_principal.gd
@@ -16,6 +16,7 @@ func _ready() -> void:
 	if len(arquivos_salvamento) > 0:
 		jogo_salvo = arquivos_salvamento[0]
 		continuar.disabled = false
+		continuar.modulate = Color(1.0, 1.0, 1.0, 1.0)
 
 #ao clicar em jogar deveria ir direto para a tela de cenas iniciais do jogo.
 func _on_jogar_pressed() -> void:

--- a/Projeto/UI/Menus/menu_principal.tscn
+++ b/Projeto/UI/Menus/menu_principal.tscn
@@ -44,7 +44,6 @@ theme = ExtResource("2_v6y4k")
 theme_override_constants/outline_size = 11
 theme_override_font_sizes/font_size = 45
 theme_override_styles/focus = SubResource("StyleBoxEmpty_2aayc")
-disabled = true
 text = "CONTINUAR"
 
 [node name="extras" type="Button" parent="CenterContainer/BotoesPrincipais"]


### PR DESCRIPTION
O botão de continuar vai ficar ativado sempre que houver um save ativo.

Para testar o botão desativado, é preciso entrar na pasta de dados do Godot e limpar os saves. No windows 11 fica em:

```C:\Users\%USER%\AppData\Roaming\Godot\app_userdata\qtftp2\Saves```
