### PR TITLE
Travar os controles de player enqaunto tem minigame em tela

### DIFF
--- a/Projeto/Cenas/Casa.tscn
+++ b/Projeto/Cenas/Casa.tscn
@@ -286,6 +286,7 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("21_tjjme")
 text = "Ação"
+uppercase = true
 
 [node name="BotaoPausa" type="TouchScreenButton" parent="Molduras"]
 process_mode = 3

--- a/Projeto/Cenas/CozinhaSolidaria.tscn
+++ b/Projeto/Cenas/CozinhaSolidaria.tscn
@@ -351,6 +351,7 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("23_q432q")
 text = "Ação"
+uppercase = true
 
 [node name="BotaoPausa" type="TouchScreenButton" parent="Molduras"]
 process_mode = 3

--- a/Projeto/UI/Eventos/CortarAlimento.gd
+++ b/Projeto/UI/Eventos/CortarAlimento.gd
@@ -1,6 +1,6 @@
 extends Control
 
-var player: Player 
+var player: Player
 
 @onready var receita: Label = $MarginContainer/PanelContainer/VBoxContainer/Receita
 @onready var imagem_evento: TextureRect = %ImagemEvento

--- a/Projeto/UI/Eventos/CortarAlimento.gd
+++ b/Projeto/UI/Eventos/CortarAlimento.gd
@@ -1,5 +1,7 @@
 extends Control
 
+var player: Player 
+
 @onready var receita: Label = $MarginContainer/PanelContainer/VBoxContainer/Receita
 @onready var imagem_evento: TextureRect = %ImagemEvento
 
@@ -26,7 +28,8 @@ func _ready() -> void:
 	%ProgressoEvento.failed.connect(_on_failed)
 	%ProgressoEvento.completed.connect(_on_completed)
 	%ProgressoEvento.start()
-
+	player=get_tree().get_first_node_in_group("player")
+	player.desativar()
 
 func close() -> void:
 	GuiTransitions.hide("Modal")
@@ -51,3 +54,6 @@ func _on_failed():
 func _on_completed():
 	Eventos.evento_realizado.emit()
 	close()
+
+func _exit_tree() -> void:
+	player.ativar()

--- a/Projeto/UI/Eventos/CortarAlimento.tscn
+++ b/Projeto/UI/Eventos/CortarAlimento.tscn
@@ -104,6 +104,22 @@ texture_normal = ExtResource("9_bb65w")
 texture_pressed = ExtResource("10_ykpfq")
 stretch_mode = 5
 
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/VBoxContainer/Label2/ProgressoEvento/BotaoAcao" index="0"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -58.0
+offset_top = -23.0
+offset_right = 59.0
+offset_bottom = 23.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 35
+text = "CORTAR"
+
 [node name="CloseButton" parent="MarginContainer/PanelContainer/VBoxContainer" index="5"]
 custom_minimum_size = Vector2(100, 100)
 theme = ExtResource("9_mct0n")

--- a/Projeto/UI/Eventos/DesenformarAlimento.gd
+++ b/Projeto/UI/Eventos/DesenformarAlimento.gd
@@ -1,5 +1,7 @@
 extends Control
 
+var player: Player 
+
 @onready var receita: Label = $MarginContainer/PanelContainer/VBoxContainer/Receita
 
 
@@ -12,7 +14,8 @@ func _ready() -> void:
 	%ProgressoEvento.failed.connect(_on_failed)
 	%ProgressoEvento.completed.connect(_on_completed)
 	%ProgressoEvento.start()
-
+	player=get_tree().get_first_node_in_group("player")
+	player.desativar()
 
 func close() -> void:
 	GuiTransitions.hide("Modal")
@@ -37,3 +40,6 @@ func _on_failed():
 func _on_completed():
 	Eventos.evento_realizado.emit()
 	close()
+
+func _exit_tree() -> void:
+	player.ativar()

--- a/Projeto/UI/Eventos/DesenformarAlimento.gd
+++ b/Projeto/UI/Eventos/DesenformarAlimento.gd
@@ -1,6 +1,6 @@
 extends Control
 
-var player: Player 
+var player: Player
 
 @onready var receita: Label = $MarginContainer/PanelContainer/VBoxContainer/Receita
 

--- a/Projeto/UI/Eventos/DesenformarCuscuz.tscn
+++ b/Projeto/UI/Eventos/DesenformarCuscuz.tscn
@@ -222,6 +222,21 @@ texture_normal = ExtResource("9_c5aef")
 texture_pressed = ExtResource("12_mf8c0")
 stretch_mode = 5
 
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/VBoxContainer/Instrucao/ProgressoEvento/BotaoAcao" index="0"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -22.0
+offset_top = -18.0
+offset_right = 18.0
+offset_bottom = 15.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "DESENFORMAR"
+
 [node name="CloseButton" parent="MarginContainer/PanelContainer/VBoxContainer" index="7"]
 custom_minimum_size = Vector2(100, 100)
 theme = ExtResource("12_l2rbf")

--- a/Projeto/UI/Eventos/misturar_alimento.gd
+++ b/Projeto/UI/Eventos/misturar_alimento.gd
@@ -1,6 +1,6 @@
 extends Control
 
-var player: Player 
+var player: Player
 
 @onready var receita: Label = $MarginContainer/PanelContainer/VBoxContainer/Receita
 @onready var imagem_evento: TextureRect = %ImagemEvento

--- a/Projeto/UI/Eventos/misturar_alimento.gd
+++ b/Projeto/UI/Eventos/misturar_alimento.gd
@@ -1,5 +1,7 @@
 extends Control
 
+var player: Player 
+
 @onready var receita: Label = $MarginContainer/PanelContainer/VBoxContainer/Receita
 @onready var imagem_evento: TextureRect = %ImagemEvento
 
@@ -17,6 +19,8 @@ func _ready() -> void:
 	%ProgressoEvento.failed.connect(_on_failed)
 	%ProgressoEvento.completed.connect(_on_completed)
 	%ProgressoEvento.start()
+	player=get_tree().get_first_node_in_group("player")
+	player.desativar()
 
 
 func close() -> void:
@@ -46,3 +50,7 @@ func _on_completed():
 
 func _on_spin_button_giro_completo(_contador: int) -> void:
 	%ProgressoEvento.do_act()
+
+
+func _exit_tree() -> void:
+	player.ativar()


### PR DESCRIPTION
Retiramos o controles do joystick e botão de ação enquanto tem um minigame em tela, evitando o player de ficar andando pela casa. Desativamos o player quando o minigame abre em cada um dos minigames e reativamos o player quando sai da arvore/ minigame sai de tela.